### PR TITLE
Fix: requests nil error

### DIFF
--- a/lib/rspec_api_documentation/example.rb
+++ b/lib/rspec_api_documentation/example.rb
@@ -55,7 +55,7 @@ module RspecApiDocumentation
     end
 
     def requests
-      filter_headers(metadata[:requests]) || []
+      filter_headers(metadata.fetch(:requests, []))
     end
 
     private


### PR DESCRIPTION
Fix example.rb `requests` method:
`example.rb:71:in 'remap_headers': undefined method 'each' for nil:NilClass`