### PR TITLE
Fallback to StringIO to prevent nil.rewind errors

### DIFF
--- a/lib/rspec_api_documentation/client_base.rb
+++ b/lib/rspec_api_documentation/client_base.rb
@@ -44,7 +44,7 @@ module RspecApiDocumentation
     end
 
     def read_request_body
-      input = last_request.env["rack.input"]
+      input = last_request.env["rack.input"] || StringIO.new
       input.rewind
       input.read
     end


### PR DESCRIPTION
## Problem

Before Rack 3.1, `last_request.env["rack.input"]` was an empty StringIO object when there wasn't a rack input.
As of Rack 3.1 `last_request.env["rack.input"]` is `nil` when there is no input.

This is a stumbling block for rspec_api_documentation's inner functionings.

## Solution, short term edition

As a "for now" solution, we can fall back in to StringIO when generating docs. This PR makes StringIO.new the default when `last_request.env["rack.input"]` is `nil`.

A good thing about this solution is that it will address the rspec doc generation problem without forcing a pin on rack. We do not want to pin rack because it is involved in production functionality and we want to be sure to keep up to date in order to capitalize on all security and performance updates.

In contrast, our posture towards rspec_api_documentation is weaker because there has [not been an official release since 2018](https://rubygems.org/gems/rspec_api_documentation/versions/6.1.0?locale=en) and the library is not in the path of production requests.

## Solution, longer term edition (not in this PR)

One of these:

* Invest in a fork of rspec_api_documentation and actively keep it up to date with the Ruby ecosystem
* Move away from using rspec_api_documentation for documentation
